### PR TITLE
feat: add multi-stage build with slim prod target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,14 +15,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Docker meta (dev)
         id: meta_dev
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: |
             sebivenlo/prj1-web
@@ -31,7 +31,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
       - name: Docker meta (prod)
         id: meta_prod
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: |
             sebivenlo/prj1-web
@@ -42,12 +42,12 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build dev
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           target: dev
@@ -55,7 +55,7 @@ jobs:
           tags: ${{ steps.meta_dev.outputs.tags }}
           labels: ${{ steps.meta_dev.outputs.labels }}
       - name: Build prod
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           target: prod

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,12 +20,23 @@ jobs:
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      - name: Docker meta
-        id: meta
+      - name: Docker meta (dev)
+        id: meta_dev
         uses: docker/metadata-action@v4
         with:
           images: |
             sebivenlo/prj1-web
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+      - name: Docker meta (prod)
+        id: meta_prod
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            sebivenlo/prj1-web
+          flavor: |
+            suffix=-prod
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -35,11 +46,19 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build
+      - name: Build dev
         uses: docker/build-push-action@v4
         with:
           context: .
+          target: dev
           load: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-    
+          tags: ${{ steps.meta_dev.outputs.tags }}
+          labels: ${{ steps.meta_dev.outputs.labels }}
+      - name: Build prod
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          target: prod
+          load: true
+          tags: ${{ steps.meta_prod.outputs.tags }}
+          labels: ${{ steps.meta_prod.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,23 @@ jobs:
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      - name: Docker meta
-        id: meta
+      - name: Docker meta (dev)
+        id: meta_dev
         uses: docker/metadata-action@v4
         with:
           images: |
             sebivenlo/prj1-web
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+      - name: Docker meta (prod)
+        id: meta_prod
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            sebivenlo/prj1-web
+          flavor: |
+            suffix=-prod
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -31,11 +42,21 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push
+      - name: Build and push dev
         uses: docker/build-push-action@v4
         with:
           context: .
+          target: dev
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta_dev.outputs.tags }}
+          labels: ${{ steps.meta_dev.outputs.labels }}
+      - name: Build and push prod
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          target: prod
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta_prod.outputs.tags }}
+          labels: ${{ steps.meta_prod.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,14 +11,14 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Docker meta (dev)
         id: meta_dev
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: |
             sebivenlo/prj1-web
@@ -27,7 +27,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
       - name: Docker meta (prod)
         id: meta_prod
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: |
             sebivenlo/prj1-web
@@ -38,12 +38,12 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push dev
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           target: dev
@@ -52,7 +52,7 @@ jobs:
           tags: ${{ steps.meta_dev.outputs.tags }}
           labels: ${{ steps.meta_dev.outputs.labels }}
       - name: Build and push prod
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           target: prod

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,51 +1,71 @@
-FROM php:8.2.29-apache
+# Multi-stage build:
+#   base — shared Apache + PHP + extensions (consumers should never FROM this)
+#   prod — slim image for deployments (no dev tooling, php.ini-production)
+#   dev  — devcontainer-friendly image (extra tooling, devuser, php.ini-development)
+#
+# `docker build .` (no --target) builds dev, matching the previous single-stage
+# behaviour so existing consumers don't break.
 
-# Set maintainer
+# ─── Stage: base ───────────────────────────────────────────────────────────
+FROM php:8.2.29-apache AS base
+
 LABEL maintainer="Martijn Bonajo"
 
-# Set the working directory
 WORKDIR /var/www/html
 
-# Install dependencies, see README
-RUN apt-get update && apt-get install -y \
-		libfreetype6-dev \
-		libjpeg62-turbo-dev \
-		libpng-dev \
+# Extensions installed here apply to both dev and prod, so any PHP code that
+# runs in dev runs in prod and vice versa.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libfreetype6-dev \
+        libjpeg62-turbo-dev \
+        libpng-dev \
         libpq-dev \
         libzip-dev \
+    && docker-php-ext-install -j$(nproc) pdo pdo_pgsql \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg IPE_GD_WITHOUTAVIF=1 \
+    && docker-php-ext-install -j$(nproc) gd exif zip \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Suppress Apache's "Could not reliably determine the server's FQDN" warning.
+RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf
+
+EXPOSE 80
+
+# ─── Stage: prod ───────────────────────────────────────────────────────────
+# Intended for deployments (e.g. the FontysVenlo developer platform). Uses
+# php.ini-production so stack traces don't leak in user-facing responses.
+# No git/gnupg/zip CLI, no devuser — Apache runs as the default www-data.
+FROM base AS prod
+
+# Match dev's upload limits so file-upload behaviour is identical in both
+# targets; only display_errors / error_reporting hardening differs.
+RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini" \
+ && sed -i 's/upload_max_filesize = .*/upload_max_filesize = 20M/g' "$PHP_INI_DIR/php.ini" \
+ && sed -i 's/post_max_size = .*/post_max_size = 80M/g' "$PHP_INI_DIR/php.ini"
+
+# ─── Stage: dev (default) ──────────────────────────────────────────────────
+# Devcontainer-friendly image with extra tooling and a non-root user that
+# devcontainers can remap to the host's UID/GID. Uses php.ini-development
+# so students see PHP errors inline while learning.
+FROM base AS dev
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
         zip \
         git \
         gnupg \
-    && docker-php-ext-install -j$(nproc) pdo \
-    && docker-php-ext-install -j$(nproc) pdo_pgsql \
-	&& docker-php-ext-configure gd --with-freetype --with-jpeg IPE_GD_WITHOUTAVIF=1\
-	&& docker-php-ext-install -j$(nproc) gd \
-    && docker-php-ext-install -j$(nproc) exif \
-    && docker-php-ext-install -j$(nproc) zip \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Set ServerName to suppress warnings
-RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf
-RUN cat /etc/apache2/mods-available/alias.conf
+RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini" \
+ && sed -i 's/upload_max_filesize = .*/upload_max_filesize = 20M/g' "$PHP_INI_DIR/php.ini" \
+ && sed -i 's/post_max_size = .*/post_max_size = 80M/g' "$PHP_INI_DIR/php.ini"
 
-# Use the default php.ini-development file as our php.ini
-# Only replace the max upload size and post size
-# TODO: create custom php.ini file
-RUN mv $PHP_INI_DIR/php.ini-development $PHP_INI_DIR/php.ini \
-    && sed -i 's/upload_max_filesize = .*/upload_max_filesize = 20M/g' $PHP_INI_DIR'/php.ini' \
-    && sed -i 's/post_max_size = .*/post_max_size = 80M/g' ${PHP_INI_DIR}'/php.ini'
-
-# Create a non-root user without hardcoding UID/GID
-# UID/GID will be patched later by devcontainers with updateRemoteUserUID
+# Create a non-root user without hardcoding UID/GID. Devcontainers patch
+# UID/GID at runtime via updateRemoteUserUID.
 RUN groupadd devgroup \
- && useradd -m -s /bin/bash -g devgroup devuser
+ && useradd -m -s /bin/bash -g devgroup devuser \
+ && chown -R devuser:devgroup /var/www/html
 
-# Ensure Apache/PHP app dir is writable by devuser
-RUN chown -R devuser:devgroup /var/www/html
-
-# Switch back to root (devcontainers will remap UID/GID at runtime)
+# Switch back to root; devcontainers remap UID/GID at runtime.
 USER root
-
-# Only expose port 80
-# We do not expect students to use HTTPS
-EXPOSE 80

--- a/README.md
+++ b/README.md
@@ -2,9 +2,27 @@
 
 The container can be found at: [https://hub.docker.com/r/sebivenlo/prj1-web](https://hub.docker.com/r/sebivenlo/prj1-web)
 
-This docker container is based on the official [php-apache](https://hub.docker.com/_/php) container. 
+This docker container is based on the official [php-apache](https://hub.docker.com/_/php) container.
 
 The base container is extended with a couple of extensions that might be needed during the project.
+
+## Variants
+
+Two image variants are published from this repo. Both share the same PHP version, extensions, and `upload_max_filesize` / `post_max_size` so application code behaves identically in both.
+
+| Tag                                     | Target | Use case                                                             |
+| --------------------------------------- | ------ | -------------------------------------------------------------------- |
+| `sebivenlo/prj1-web:<version>`          | `dev`  | Devcontainer / local development. Ships `git`, `gnupg`, `zip` CLI, a non-root `devuser` for UID/GID remapping, and `php.ini-development` (errors visible inline). |
+| `sebivenlo/prj1-web:<version>-prod`     | `prod` | Deployments (e.g. the FontysVenlo developer platform). No dev tooling, no `devuser`, and `php.ini-production` (stack traces not shown in HTTP responses). |
+
+Build a specific target locally:
+
+```bash
+docker build --target prod -t prj1-web:prod .
+docker build --target dev  -t prj1-web:dev  .
+```
+
+`docker build .` (no `--target`) builds `dev`, matching the previous single-stage behaviour.
 
 ## Extensions:
 


### PR DESCRIPTION
## Summary

Adds a `prod` target alongside the existing dev image. Motivation: downstream consumers (the new FontysVenlo developer platform CI pipeline, see [UOL1.1-Template#8](https://github.com/FontysVenlo/UOL1.1-Template/pull/8)) need an image with the same PHP + extensions as the devcontainer image, but without the devcontainer tooling (`git`, `gnupg`, `zip` CLI, `devuser`) and without `php.ini-development`. Today they'd have to either mirror this Dockerfile downstream (drift risk) or accept a bloated prod image with `display_errors=On`. Multi-stage here keeps a single source of truth.

## Design choices (please weigh in)

- **`base` stage is private** — installs Apache + PHP 8.2.29 + all PHP extensions + `ServerName localhost`. Both `dev` and `prod` extend it, so any code that runs against dev runs against prod.
- **`dev` is last** so `docker build .` (no `--target`) keeps producing the dev image — no breaking change for existing consumers.
- **Prod uses `php.ini-production`** (display_errors=Off, log_errors=On) — the more conservative default for an image shared beyond uol11. If you'd rather keep error visibility in student deployments to aid debugging, it's a one-line flip in the `prod` stage; happy to switch.
- **Upload limits (`upload_max_filesize=20M`, `post_max_size=80M`) are applied in both targets** so file-upload behaviour matches between dev and prod regardless of base ini.
- **No `devuser` in prod** — Apache runs as default `www-data`.

## Tags published

| Tag                                 | Target | Notes                              |
| ----------------------------------- | ------ | ---------------------------------- |
| `sebivenlo/prj1-web:<version>`      | `dev`  | unchanged behaviour                |
| `sebivenlo/prj1-web:<version>-prod` | `prod` | new; `flavor: suffix=-prod` in CI  |

Both `build.yml` (PR check) and `release.yml` (tag push) now build both targets. Release pushes both multi-arch (`amd64`+`arm64`).

## Test plan

- [x] `docker build --target prod .` succeeds locally
- [x] `docker build --target dev .` succeeds locally
- [x] Both targets have identical PHP extensions: pdo, pdo_pgsql, gd, exif, zip
- [x] Both targets: `upload_max_filesize=20M`, `post_max_size=80M`
- [x] Prod: `display_errors=Off`; dev: `display_errors=On`
- [x] Dev has `git` and `zip` CLI; prod does not
- [x] CI green on both `build.yml` jobs (Build dev / Build prod)
- [ ] After merge + tag, both image tags appear on Docker Hub (`<version>` and `<version>-prod`)